### PR TITLE
Redirect root domain to new site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://growtogether.kingdomone.com" />
+    <title>Redirecting...</title>
+  </head>
+  <body>
+    <p>If you are not redirected, <a href="https://growtogether.kingdomone.com">click here</a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
Adds a redirect in public/index.html to point growtogether.church to https://growtogether.kingdomone.com. This ensures visitors to the root domain are automatically redirected to the new site.